### PR TITLE
Update jquery.mmenu.bootstrap4.ts

### DIFF
--- a/src/wrappers/bootstrap/jquery.mmenu.bootstrap4.ts
+++ b/src/wrappers/bootstrap/jquery.mmenu.bootstrap4.ts
@@ -104,7 +104,7 @@
 	function cloneDropdown( $d )
 	{
 		var $ul = $('<ul />');
-		$d.children()
+		$d.find( '.dropdown-item, .dropdown-divider' )
 			.each(function() {
 				var $di = $(this),
 					$li = $('<li />');


### PR DESCRIPTION
Revert a change to avoid adding empty li tags to the Boostrap4 wrapper. The children() function is only going 1 level deep.